### PR TITLE
Fixes folder `var/logs` to `var/log` for log files

### DIFF
--- a/sfcasts/ep2-security/test-reset-database.md
+++ b/sfcasts/ep2-security/test-reset-database.md
@@ -91,7 +91,7 @@ And... no more output! *Now* the logs are stored in `var/log/test.log`. If you
 tail that file...
 
 ```terminal-silent
-tail var/log/test.log
+tail -f var/log/test.log
 ```
 
 there it is!

--- a/sfcasts/ep2-security/test-reset-database.md
+++ b/sfcasts/ep2-security/test-reset-database.md
@@ -87,11 +87,11 @@ This installs Monolog. When it finishes... try running the tests again:
 php bin/phpunit
 ```
 
-And... no more output! *Now* the logs are stored in `var/logs/test.log`. If you
+And... no more output! *Now* the logs are stored in `var/log/test.log`. If you
 tail that file...
 
 ```terminal-silent
-tail var/logs/test.log
+tail var/log/test.log
 ```
 
 there it is!


### PR DESCRIPTION
Don't know if it's an old default but my logs are going to `var/log/` and docu is saying same (https://symfony.com/doc/current/logging.html#where-logs-are-stored).
Thank you for this marvolous tutorials. It's really fun to read them and besides ;) you got a lot of practical knowledge.